### PR TITLE
Need to make Canonical url character limit larger

### DIFF
--- a/src/extensions/Seo/Seo.js
+++ b/src/extensions/Seo/Seo.js
@@ -9,7 +9,7 @@ import {
   RadioButtonField,
   FormLabel,
   Note,
-  HelpText
+  HelpText,
 } from '@contentful/forma-36-react-components';
 import { get, isEmpty, omit, debounce } from 'lodash';
 import '@contentful/forma-36-react-components/dist/styles.css';
@@ -20,6 +20,7 @@ import SingleAssetWithButton from '../../shared/components/SingleAssetWithButton
 const Seo = ({ sdk }) => {
   const [seoObject, setSeoObject] = useState(sdk.field.getValue());
   const [selected, setSelected] = useState('preview');
+  const [showCanonicalWarning, setShowCanonicalWarning] = useState(false);
 
   const onFieldChange = (field) => {
     sdk.field
@@ -36,6 +37,16 @@ const Seo = ({ sdk }) => {
   };
 
   const onFieldChangeDebounce = debounce(
+    (field) => {
+      return onFieldChange(field);
+    },
+    500,
+    {
+      leading: false
+    }
+  );
+
+  const onFieldChangeDebounceCanonical = debounce(
     (field) => {
       return onFieldChange(field);
     },
@@ -187,10 +198,17 @@ const Seo = ({ sdk }) => {
           labelText="Canonical URL"
           helpText="Canonical specifies to search engines your preferred URL. Default is current page URL."
           textInputProps={{
-            maxLength: 60,
+            maxLength: 256,
             onKeyPress: (e) => onFieldChangeDebounce(e.currentTarget),
             onBlur: (e) => onFieldChange(e.currentTarget),
-            testId: 'Seo-tabpanel-general-canonical'
+            testId: 'Seo-tabpanel-general-canonical',
+            onChange: (e) => {
+              if (e.currentTarget?.value?.length > 60) {
+                setShowCanonicalWarning(true);
+              } else {
+                setShowCanonicalWarning(false);
+              }
+            }
           }}
           value={
             isEmpty(get(seoObject, 'canonical.value'))
@@ -200,6 +218,11 @@ const Seo = ({ sdk }) => {
           countCharacters
           className="fieldset"
         />
+        {showCanonicalWarning && (
+          <HelpText style={{ color: 'orange' }}>
+            Best practices call for canonical URLs to be 60 characters or less.
+          </HelpText>
+        )}
         <FieldGroup className="fieldset">
           <FormLabel className="fieldset" htmlFor="robots">
             Would you like this content to be indexed by search engines?


### PR DESCRIPTION
Raised canonical url character limit to 256 and added warning message if it is larger than 60

60 or less characters:
![Screen Shot 2022-09-12 at 11 32 46 AM](https://user-images.githubusercontent.com/51485419/189695345-a8870710-fe5e-4daf-a9d3-683d20376dc8.png)

More than 60 characters:
![Screen Shot 2022-09-12 at 11 32 59 AM](https://user-images.githubusercontent.com/51485419/189695893-b63a7536-9f56-4ab0-b915-ffa25a930533.png)
